### PR TITLE
Bump org.apache.maven.plugins:maven-failsafe-plugin from 3.3.0 to 3.3…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -554,7 +554,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <configuration>
                     <argLine>${maven.test.argLine}</argLine>
                     <skipExec>${skipIT}</skipExec>


### PR DESCRIPTION
….1 (#344)

Bumps [org.apache.maven.plugins:maven-failsafe-plugin](https://github.com/apache/maven-surefire) from 3.3.0 to 3.3.1.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.0...surefire-3.3.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-patch ...